### PR TITLE
Fix two PHP 8+ fatal errors

### DIFF
--- a/shortcode.php
+++ b/shortcode.php
@@ -51,6 +51,10 @@ function custom_post_widget_shortcode ( $atts ) {
 
 		$located = locate_template( $template );
 
+		if ( empty( $located ) ) {
+			return $content;
+		}
+
 		$template_in_theme_or_parent_theme = (
 			0 === strpos ( realpath ( $located ), realpath ( get_stylesheet_directory() ) ) ||
 			0 === strpos ( realpath ( $located ), realpath ( get_template_directory() ) )

--- a/widget.php
+++ b/widget.php
@@ -88,6 +88,9 @@ class custom_post_widget extends WP_Widget {
 		$show_featured_image = isset($instance['show_featured_image']) ? $instance['show_featured_image'] : false;
 		$apply_content_filters = isset($instance['apply_content_filters']) ? $instance['apply_content_filters'] : false;
 		$content_post = get_post( $custom_post_id );
+		if ( ! $content_post ) {
+			return;
+		}
 		$post_status = get_post_status( $custom_post_id );
 		$content = $content_post->post_content;
 		if ( $post_status == 'publish' ) {


### PR DESCRIPTION
## Summary

Two defensive guards to prevent fatal errors on PHP 8+, both fully backward-compatible with PHP 5.2+.

- **widget.php** — `get_post()` can return `null` when the referenced content block has been trashed or deleted. Accessing `->post_content` on `null` is a fatal error on PHP 8+. Added an early return, consistent with the existing pattern in `custom-post-widget.php` line 118.
- **shortcode.php** — When the `template` shortcode attribute references a file that does not exist in the active theme, `locate_template()` returns an empty string. `realpath('')` returns `false`, and `strpos(false, ...)` throws a `TypeError` on PHP 8+. Added an early return when `locate_template()` finds nothing.

## Test plan

- [ ] Verify widget renders correctly when the content block exists
- [ ] Verify widget does not crash when the content block has been deleted
- [ ] Verify `[content_block template="nonexistent.php"]` shortcode does not crash
- [ ] Verify `[content_block template="existing.php"]` shortcode still loads the template
- [ ] Test on PHP 7.x and PHP 8.x